### PR TITLE
Keep backward compatibility for Rails 4

### DIFF
--- a/lib/turbolinks.rb
+++ b/lib/turbolinks.rb
@@ -11,8 +11,13 @@ module Turbolinks
       ActiveSupport.on_load(:action_controller) do
         ActionController::Base.class_eval do
           include XHRHeaders, Cookies, XDomainBlocker, Redirection
-          before_action :set_xhr_redirected_to, :set_request_method_cookie
-          after_action :abort_xdomain_redirect
+          if respond_to?(:before_action)
+            before_action :set_xhr_redirected_to, :set_request_method_cookie
+            after_action :abort_xdomain_redirect
+          else
+            before_filter :set_xhr_redirected_to, :set_request_method_cookie
+            after_filter :abort_xdomain_redirect
+          end
         end
 
         ActionDispatch::Request.class_eval do
@@ -25,7 +30,11 @@ module Turbolinks
 
       ActiveSupport.on_load(:action_view) do
         (ActionView::RoutingUrlFor rescue ActionView::Helpers::UrlHelper).module_eval do
-          prepend XHRUrlFor
+          if defined?(prepend) && Rails.version >= '4'
+            prepend XHRUrlFor
+          else
+            include LegacyXHRUrlFor
+          end
         end
       end unless RUBY_VERSION =~ /^1\.8/
     end

--- a/lib/turbolinks/xhr_url_for.rb
+++ b/lib/turbolinks/xhr_url_for.rb
@@ -2,6 +2,17 @@ module Turbolinks
   # Corrects the behavior of url_for (and link_to, which uses url_for) with the :back
   # option by using the X-XHR-Referer request header instead of the standard Referer
   # request header.
+  module LegacyXHRUrlFor
+    def self.included(base)
+      base.alias_method_chain :url_for, :xhr_referer
+    end
+
+    def url_for_with_xhr_referer(options = {})
+      options = (controller.request.headers["X-XHR-Referer"] || options) if options == :back
+      super options
+    end
+  end
+
   module XHRUrlFor
     def url_for(options = {})
       options = (controller.request.headers["X-XHR-Referer"] || options) if options == :back


### PR DESCRIPTION
I added conditional checks to keep the backward compatibility. If you do not mind merge-squashing it into your branch, I do not mind either. I just need to have it fixed and I did not want to open another PR since you started working on this first. But if you are not interested in working on this any more, let me know and I will open a PR directly against turbolinks-classic.